### PR TITLE
wp-env support for docker compose configuration object

### DIFF
--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -170,8 +170,15 @@ module.exports = async function start( {
 
 	spinner.text = 'Starting WordPress.';
 
+	const extraServices = config?.dockerCompose?.services || {};
 	await dockerCompose.upMany(
-		[ 'wordpress', 'tests-wordpress', 'cli', 'tests-cli' ],
+		[
+			'wordpress',
+			'tests-wordpress',
+			'cli',
+			'tests-cli',
+			...Object.keys( extraServices ),
+		],
 		{
 			...dockerComposeConfig,
 			commandOptions: shouldConfigureWp

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -70,6 +70,7 @@ module.exports = async function loadConfig( configDirectoryPath ) {
 		] ),
 		lifecycleScripts: config.lifecycleScripts,
 		env: config.env,
+		dockerCompose: config.env.development.dockerCompose,
 	};
 };
 

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -231,6 +231,7 @@ async function getDefaultConfig(
 			afterClean: null,
 			afterDestroy: null,
 		},
+		dockerCompose: null,
 		env: {
 			development: {},
 			tests: {
@@ -352,6 +353,18 @@ async function parseRootConfig( configFile, rawConfig, options ) {
 		parsedConfig.lifecycleScripts = rawConfig.lifecycleScripts;
 	}
 
+	// Parse the docker-compose config.
+	if ( rawConfig.dockerCompose !== undefined ) {
+		checkObjectWithValues(
+			configFile,
+			'dockerCompose',
+			rawConfig.dockerCompose,
+			[ 'object' ],
+			false
+		);
+		parsedConfig.dockerCompose = rawConfig.dockerCompose;
+	}
+
 	// Parse the environment-specific configs so they're accessible to the root.
 	parsedConfig.env = {};
 	if ( rawConfig.env ) {
@@ -413,6 +426,7 @@ async function parseEnvironmentConfig(
 		switch ( key ) {
 			case 'testsPort':
 			case 'lifecycleScripts':
+			case 'dockerCompose':
 			case 'env': {
 				if ( options.rootConfig ) {
 					continue;


### PR DESCRIPTION
Changes to allow wp-env config to take docker compose configuration.

To install wp-env from a local clone, 

1. cd into `packages/env/`
2. `npm i -g .`


See how to create a cloudflare tunnel here: https://noted.lol/cloudflare-tunnel-and-zero-trust/

Make sure to keep the port as 443 so that WP doesn't try to redirect to another port.

Example `.wp-env.override.json` to add a cloudflare tunnel container alongside wp-env:

```
{
    "plugins": [
        "./plugins/woocommerce",
        "./plugins/woocommerce-beta-tester",
        "https://downloads.wordpress.org/plugin/woocommerce-payments.zip",
        "https://downloads.wordpress.org/plugin/query-monitor.zip",
        "https://downloads.wordpress.org/plugin/wp-mail-logging.zip",
        "https://github.com/woocommerce/wc-smooth-generator/releases/latest/download/wc-smooth-generator.zip"
    ],
    "config": {
        "JETPACK_AUTOLOAD_DEV": true,
        "WP_DEBUG_LOG": true,
        "WP_DEBUG_DISPLAY": true,
        "ALTERNATE_WP_CRON": true,
        "WP_HOME": "https://<your-cloudflare-domain-name.tld>",
        "WP_SITEURL": "https://your-cloudflare-domain-name.tld>"
    },
    "env": {
	    "development": {
                "port": 443
	    }
    },
    "dockerCompose": {
        "services": {
            "cloudflare-tunnel": {
        "container_name": "cloudflared-wp-tunnel",
        "image": "cloudflare/cloudflared",
        "restart": "unless-stopped",
        "command": "tunnel run",
        "environment": [
                    "TUNNEL_TOKEN=<Your cloudflare tunnel token, e.g eyJhIjo...>"
                ]
            }
        }
    }
}
```